### PR TITLE
Use `npm start` instead of `nf start web`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create an `.env` file in the root of the project and add your environment variab
 Run the server:
 
 ```shell
-nf start web
+npm start
 ```
 
 Test the client in your browser: [http://localhost:5000](http://localhost:5000)


### PR DESCRIPTION
This avoids new developers having to set their PATH correctly to follow the basic instructions for running the snake.

`npm run ...` automatically adds `node_modules/.bin` to the PATH, so the `nf` command is available.